### PR TITLE
Breadcrumbs

### DIFF
--- a/docs/assets/css/breadcrumbs.css
+++ b/docs/assets/css/breadcrumbs.css
@@ -1,0 +1,23 @@
+.breadcrumbs {
+    display: flex;
+    font-family: 'Museo Sans Rounded 300';
+    padding: 1em 0;
+}
+
+.breadcrumbs__separator {
+    margin: 0 0.75em;
+    color: hsl(44, 26%, 51%);
+}
+
+.breadcrumbs__link {
+    text-decoration: none;
+    color: hsl(44, 26%, 51%);
+}
+
+.breadcrumbs__link:hover {
+    color: hsl(44, 26%, 31%);
+}
+
+.breadcrumbs__text {
+    color: hsl(44, 26%, 31%);
+}

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -6,9 +6,9 @@
 @import "./footer.css";
 @import "./header.css";
 @import "./topline-some-links.css";
-
+@import "./breadcrumbs.css";
 a {
-  text-decoration: none;
+    text-decoration: none;
 }
 
 body {

--- a/docs/assets/js/breadcrumbs.js
+++ b/docs/assets/js/breadcrumbs.js
@@ -1,0 +1,51 @@
+function breadcrumbs(array, parent) {
+    parent.innerHTML = "";
+    let arr = [];
+    array.forEach(obj => {
+        let linkElm;
+        if (obj.link === "") {
+            linkElm = createTextElement(obj.title);
+        } else {
+            linkElm = createLinkElement(obj.title, obj.link);
+        }
+        let newObj = {
+            separator: createSeparator("/"),
+            link: linkElm
+        };
+        arr.push(newObj);
+    });
+
+    breadcrumbHTML();
+
+    function createLinkElement(title, link) {
+        let linkElm = document.createElement("A");
+        linkElm.classList.add("breadcrumbs__link");
+        linkElm.href = link;
+        linkElm.textContent = title;
+        return linkElm;
+    }
+
+    function createTextElement(text) {
+        let txtElm = document.createElement("SPAN");
+        txtElm.classList.add("breadcrumbs__text");
+        txtElm.textContent = text;
+        return txtElm;
+    }
+
+    function createSeparator(character) {
+        let separatorElm = document.createElement("SPAN");
+        separatorElm.classList.add("breadcrumbs__separator");
+        separatorElm.innerHTML = character;
+        return separatorElm;
+    }
+
+    function breadcrumbHTML() {
+        arr.forEach(obj => {
+            parent.appendChild(obj.separator);
+            parent.appendChild(obj.link);
+        });
+    }
+}
+
+
+export default breadcrumbs;

--- a/docs/assets/js/shop-category-list.js
+++ b/docs/assets/js/shop-category-list.js
@@ -1,0 +1,17 @@
+import breadcrumbs from "./breadcrumbs.js";
+
+let dummyArray = [
+
+    {
+        title: "Amplifiers",
+        link: "?category=amplifiers"
+    }, {
+        title: "CD players",
+        link: ""
+    }
+
+];
+
+let breadcrumbsContainer = document.querySelector(".breadcrumbs__container");
+
+breadcrumbs(dummyArray, breadcrumbsContainer);

--- a/docs/shop-category-list.html
+++ b/docs/shop-category-list.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HiFi Corner</title>
+    <link rel="stylesheet" href="./assets/css/style.css">
+</head>
+
+<body>
+    <div class="breadcrumbs">
+        <a class="breadcrumbs__link" href="index.html">Home</a>
+        <div class="breadcrumbs__container">
+            <!-- JS Content -->
+        </div>
+    </div>
+    <script src="./assets/js/shop-category-list.js" type="module"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Tried to make the breadcrumbs reusable, so it can be used in the single view page also.

Usage:
Pass in an array containing objects that each contain keys "title" and "link", like so (example):
```JavaScript
let arr = [
    {
        title: "Amplifiers",
        link: "?category=amplifiers"
    }
]
breadcrumbs(arr, containerElement);
```